### PR TITLE
fix: use env bash instead of absolute bin

### DIFF
--- a/docker/configure_cdb.sh
+++ b/docker/configure_cdb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Paths

--- a/docker/configure_crisalid_bus.sh
+++ b/docker/configure_crisalid_bus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ENV_FILE="$ROOT_DIR/.env"

--- a/docker/configure_keycloak.sh
+++ b/docker/configure_keycloak.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # Paths

--- a/docker/encode_rabbitmq_password.sh
+++ b/docker/encode_rabbitmq_password.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function get_byte()
 {


### PR DESCRIPTION
fix:
- use env bash instead of absolute bin

you can see more info [SC2239](https://www.shellcheck.net/wiki/SC2239), to use `/usr/bin/env bash` 