### PR TITLE
fixed ports definition for harvester + sovisuplus

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -8,6 +8,8 @@ CRISALID_BUS_USER=crisalid_bus_user
 CRISALID_BUS_PASSWORD=xxxxxxxxxxxxxxxxx
 CRISALID_BUS_AMQP_PORT=5672
 
+HARVESTER_UI_PORT=8000
+
 LDAP_HOST=ldaps://my-ldap-host
 LDAP_BIND_DN='cn=my-user,ou=admin,dc=my-univ,dc=fr'
 LDAP_BIND_PASSWORD='my-password'

--- a/docker/harvester/harvester.yaml
+++ b/docker/harvester/harvester.yaml
@@ -53,7 +53,7 @@ services:
     image: crisalidesr/svp-harvester:latest
     container_name: harvester-ui
     ports:
-      - 8000:8000
+      - "${HARVESTER_UI_PORT}:8000"
     environment:
       - APP_ENV=DEV
       - API_HOST=http://localhost:8000

--- a/docker/sovisuplus/sovisuplus.yaml
+++ b/docker/sovisuplus/sovisuplus.yaml
@@ -29,8 +29,8 @@ services:
     image: crisalidesr/sovisuplus:latest
     container_name: sovisuplus
     ports:
-      - 3000:3000
-      - 3001:3001
+      - "${SOVISUPLUS_PORT}:3000"
+      - "${SVP_WS_PORT}:3001"
     environment:
       - INIT_ROLES_ON_START=true
       - RBAC_ROLES_FILE=/config/rbac.roles.yaml


### PR DESCRIPTION
I fixed the port specifications in the docker compose for the harvester and sovisuplus.

It seems that the docker compose of keycloak, cdb and ikg have the same problem.