### PR TITLE
Fix OpenAlex download script for new S3 jsonl layout

### DIFF
--- a/docker/scripts/download_openalex_tree.sh
+++ b/docker/scripts/download_openalex_tree.sh
@@ -9,18 +9,20 @@ DEST="${1:-$(dirname "$(realpath "$0")")/../ikg/data/openalex}"
 
 for entity in "${ENTITIES[@]}"; do
   echo "[$entity] fetching manifest..."
-  manifest=$(curl -sf "${BUCKET}/data/${entity}/manifest")
+  manifest=$(curl -sf "${BUCKET}/data/jsonl/${entity}/manifest.json") || {
+    echo "[$entity] ERROR: failed to fetch manifest" >&2; exit 1;
+  }
   keys=$(echo "$manifest" | grep -oP '(?<="s3://openalex/)[^"]+\.gz')
   total=$(echo "$keys" | wc -l)
   echo "[$entity] $total file(s)"
   while IFS= read -r key; do
-    # key = data/<entity>/updated_date=.../part_XXXX.gz — strip leading "data/"
-    local_path="${DEST}/${key#data/}"
+    # key = data/jsonl/<entity>/updated_date=.../part_XXXX.gz — strip leading "data/jsonl/"
+    local_path="${DEST}/${key#data/jsonl/}"
     local_path="${local_path%.gz}"   # store decompressed
     [ -f "$local_path" ] && continue
     mkdir -p "$(dirname "$local_path")"
     chmod a+rwx "$(dirname "$local_path")"
-    echo "  ${key#data/}"
+    echo "  ${key#data/jsonl/}"
     curl -sf "${BUCKET}/${key}" | gunzip > "${local_path}.tmp"
     mv "${local_path}.tmp" "$local_path"
     chmod a+rw "$local_path"


### PR DESCRIPTION
OpenAlex restructured its S3 bucket (late June 2026): entity snapshots moved from `data/<entity>/` to `data/jsonl/<entity>/` and the manifest was renamed `manifest.json`. The old URL now returns 404, which `curl -sf` + `set -e` turned into a silent exit right after "fetching manifest...".

- Fetch `data/jsonl/<entity>/manifest.json`
- Strip the new `data/jsonl/` prefix so the local layout is unchanged (`<entity>/updated_date=.../part_XXXX`)
- Fail loudly with an error message if the manifest fetch fails

Tested locally: all 9 files for topics/domains/fields/subfields download and decompress correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)