### PR TITLE
Make OVERRIDE_LDAP_STRUCTURE_DATA_FROM_SPREADSHEET configurable via docker/.env

### DIFF
--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -13,6 +13,8 @@ CRISALID_BUS_AMQP_PORT=5672
 LDAP_HOST=ldaps://my-ldap-host
 LDAP_BIND_DN='cn=my-user,ou=admin,dc=my-univ,dc=fr'
 LDAP_BIND_PASSWORD='my-password'
+# Set to True to override LDAP structure data with the structures spreadsheet (default False)
+OVERRIDE_LDAP_STRUCTURE_DATA_FROM_SPREADSHEET=False
 
 KEYCLOAK_SCHEME=http
 KEYCLOAK_PORT=8080

--- a/docker/configure_cdb.sh
+++ b/docker/configure_cdb.sh
@@ -134,6 +134,7 @@ if [ -f "$TEMPLATE_ENV" ]; then
   export CDB_REDIS_PORT=6379
   export CDB_REDIS_DB=0
   export RESTART_TRIGGER="$(date +%s)"
+  export OVERRIDE_LDAP_STRUCTURE_DATA_FROM_SPREADSHEET="${OVERRIDE_LDAP_STRUCTURE_DATA_FROM_SPREADSHEET:-False}"
 
   # Required variables
   : "${LDAP_HOST:?Missing LDAP_HOST in environment}"


### PR DESCRIPTION
Exports OVERRIDE_LDAP_STRUCTURE_DATA_FROM_SPREADSHEET (default False) in configure_cdb.sh so the value set in docker/.env is injected into the generated dags/.env. Documents the variable in .env.sample.

Companion PR in crisalid-directory-bridge turns the hardcoded template value into an envsubst placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)